### PR TITLE
Add target deployment branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,9 @@ deploy:
   skip_cleanup: true
   github_token: $GITHUB_API_KEY # Set in travis-ci.org dashboard
   local_dir: _site
-  repo: https://github.com/psadmin-io/psadmin-io.github.io.git
+  repo: psadmin-io/psadmin-io.github.io
   fqdn: wiki.psadmin.io
+  target_branch: master
   on:
     branch: master
 env:


### PR DESCRIPTION
Travis-CI defaults to `gh-pages`. We are using `master`.