### PR TITLE
Add Event Mapping reference links

### DIFF
--- a/_data/development.yml
+++ b/_data/development.yml
@@ -1,0 +1,1 @@
+Event Mapping Links: "/posts/development/event_mapping_links/"

--- a/posts/development/event_mapping_links.md
+++ b/posts/development/event_mapping_links.md
@@ -1,0 +1,26 @@
+---
+title: Event Mapping Links
+layout: en
+permalink: /posts/development/event_mapping_links/
+---
+
+## A collection of links about Even Mapping
+
+*Chris Malek on Event Mapping*
+
+* [Discovering Event Mapping](http://www.cedarhillsgroup.com/knowledge-base/kbarticles/PT855-assigning-application-class-peoplecode-to-component-events)
+
+*Colton Fischer on Event Mapping*
+
+* [Blog posts about Event Mapping](http://www.peoplesoftmods.com/category/emf/)
+
+*Sasank Vemana on Event Mapping*
+
+* [Blog posts about Event Mapping](https://pe0ples0ft.blogspot.com/search?q=Event+mapping)
+
+*psadmin.io on Event Mapping*
+
+* [Event Mapping Demo](http://psadmin.io/2016/02/10/8-55-event-mapping-demo/)
+* [Interview with Colton Fischer on Event Mapping](http://psadmin.io/2016/11/18/55-2fa-and-event-mapping-w-colton-fischer/)
+* [blog posts and podcast search](http://psadmin.io/?s=event+mapping)
+* [Reduce your customizations](http://psadmin.io/2015/12/29/8-55-reduce-your-customizations/)


### PR DESCRIPTION
Create a list of useful blog posts and interviews about the Event Mapping feature.