### PR TITLE
Add link to video

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ On the left are folder to group the various topics related to PeopleSoft Adminst
 
 Anyone can contribute to the Communtiy Wiki.
 
-There are two ways to contribute: online using GitHub, or on your local machine with `git` and a text editor. 
+There are two ways to contribute: online using GitHub, or on your local machine with `git` and a text editor. [For a video overview on how to use Github, check it out on the main wiki site](https://wiki.psadmin.io).
 
 **To edit an existing document:**
 


### PR DESCRIPTION
Video is shown on the main wiki.psadmin.io site due to security we've configured with Wistia.