### PR TITLE
fix permalink typo

### DIFF
--- a/admin/tuxedo_port_block.md
+++ b/admin/tuxedo_port_block.md
@@ -1,7 +1,7 @@
 ---
 title: Unblock Tuxedo
 layout: en
-permalink: /posts/admin/unbock_tuxedo/
+permalink: /posts/admin/unblock_tuxedo/
 ---
 
 ## Unblock Tuxedo Connection Due Failed Logins


### PR DESCRIPTION
Block was spelled bock in the permalink.